### PR TITLE
Fixing the bug with overlay

### DIFF
--- a/app/components/Board.tsx
+++ b/app/components/Board.tsx
@@ -54,7 +54,10 @@ export default function Board() {
     setSelectedCardAndAction,
   ] = useState<SelectedCardAndAction | null>(null);
 
-  const handleOpen = () => {
+  const handleOpen = (event) => {
+    if (event.type === 'focus') {
+      return;
+    }
     setOpen(true);
   };
 


### PR DESCRIPTION
#11 focus type of event is no longer opening the overlay

If the event type is focus, don't open the overlay.